### PR TITLE
Add redirect from old site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 group :jekyll_plugins do
   gem 'github-pages'
+  gem 'jekyll-redirect-from'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-redirect-from
 
 BUNDLED WITH
    1.17.2

--- a/_config.yml
+++ b/_config.yml
@@ -25,3 +25,5 @@ address:
 markdown: kramdown
 permalink: pretty
 
+plugins:
+  - jekyll-redirect-from

--- a/index.html
+++ b/index.html
@@ -1,5 +1,7 @@
 ---
 layout: default
+redirect_from: 
+    - /nsbikers/
 ---
 
 <div class="home">


### PR DESCRIPTION
Some sites were still linking to the old wordpress redirect nsbikers.
This redirects those to the home page.