### PR TITLE
Fix double base url

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ "/" | prepend: site.baseurl }}">
+  <script>location="{{ "/" | prepend: site.baseurl }}"</script>
+  <meta http-equiv="refresh" content="0; url={{ "/" | prepend: site.baseurl }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ "/" | prepend: site.baseurl }}">Click here if you are not redirected.</a>
+</html>


### PR DESCRIPTION
The redirect plugin combines the site url and site baseurl. Because we
are using the full https for the base url as well as the url (due to
https errors when serving css and js content) the url appears twice,
this customises the redirect page so that it only ever redirects to the
home page.